### PR TITLE
Fix logic for reading remaining data after incomplete read

### DIFF
--- a/src/ClientCommunicator.cpp
+++ b/src/ClientCommunicator.cpp
@@ -432,14 +432,13 @@ bool ClientCommunicator::clientThread() {
                         if (size < header.size) {
                             ALOGW("%s(%d) : Incomplete data read %zd/%u bytes", __func__, mClientId,
                                   size, header.size);
-                            size_t remaining_size = header.size;
-                            remaining_size -= size;
-                            while (remaining_size > 0) {
-                                if ((size = recv(mClientFd, mSocketBuffer.data() + size,
-                                                 remaining_size, MSG_WAITALL)) > 0) {
-                                    remaining_size -= size;
+                            size_t bytes_read = size;
+                            while (bytes_read < header.size) {
+                                if ((size = recv(mClientFd, mSocketBuffer.data() + bytes_read,
+                                                 header.size - bytes_read, MSG_WAITALL)) > 0) {
+                                    bytes_read += size;
                                     ALOGI("%s(%d) : Read-%zd after Incomplete data, remaining-%lu",
-                                          __func__, mClientId, size, remaining_size);
+                                          __func__, mClientId, size, header.size - bytes_read);
                                 }
                             }
                             size = header.size;


### PR DESCRIPTION
The buffer pointer provided to the socket read was not getting incremented within the while loop that attempts to read the remaining data, after an incomplete read.

Fixed the logic to increment the buffer pointer for each iteration of the while loop.

Tracked-on: OAM-105274
Signed-off-by: Anoob Anto K <anoob.anto.kodankandath@intel.com>