### PR TITLE
Fix for black camera preview observed in AIC app for H265 config

### DIFF
--- a/src/onevpl-video-decode/MfxDecoder.cpp
+++ b/src/onevpl-video-decode/MfxDecoder.cpp
@@ -202,18 +202,18 @@ mfxStatus MfxDecoder::SetVideoParameters(uint32_t codec_type) {
             mMfxVideoDecParams.mfx.SamplingFactorH[0] = 2;
             switch (mResHeight) {
                 case android::VirtualCamera3::DECODER_SUPPORTED_RESOLUTION_480P:
-                    mMfxVideoDecParams.mfx.CodecLevel = MFX_LEVEL_HEVC_31;
+                    mMfxVideoDecParams.mfx.CodecLevel = MFX_LEVEL_HEVC_51;
                     mMfxVideoDecParams.mfx.FrameInfo.Height = mResHeight;
                     mMfxVideoDecParams.mfx.FrameInfo.BufferSize = 31457920;
                     break;
                 case android::VirtualCamera3::DECODER_SUPPORTED_RESOLUTION_720P:
-                    mMfxVideoDecParams.mfx.CodecLevel = MFX_LEVEL_HEVC_31;
+                    mMfxVideoDecParams.mfx.CodecLevel = MFX_LEVEL_HEVC_51;
                     mMfxVideoDecParams.mfx.FrameInfo.Height = mResHeight +
                                                               CODEC_ROUND_OFF_PIXELS_16;
                     mMfxVideoDecParams.mfx.FrameInfo.BufferSize = 48235776;
                     break;
                 case android::VirtualCamera3::DECODER_SUPPORTED_RESOLUTION_1080P:
-                    mMfxVideoDecParams.mfx.CodecLevel = MFX_LEVEL_HEVC_4;
+                    mMfxVideoDecParams.mfx.CodecLevel = MFX_LEVEL_HEVC_51;
                     mMfxVideoDecParams.mfx.FrameInfo.Height = mResHeight +
                                                               CODEC_ROUND_OFF_PIXELS_8;
                     mMfxVideoDecParams.mfx.FrameInfo.BufferSize = 71305088;


### PR DESCRIPTION
When camera is launched using the AIC-Client application, there is no preview and a black screen is seen.

once the camera-vhal receives the encoded frame from client, it will decode the frame but In this case, after receiving the frame from client, decoding the frame is failing with error code -14 that is MFX_ERR_INCOMPATIBLE_VIDEO_PARAM error.

Decoder param codeclevel was not set correctly, required codeclevel for H265 is 51.

Tracked-on: OAM-105522
Signed-off-by: Singh, Sapna1 <sapna1.singh@intel.com>