### PR TITLE
Fix for black camera preview observed in AIC app for H265 config

### DIFF
--- a/include/onevpl-video-decode/MfxDecoder.h
+++ b/include/onevpl-video-decode/MfxDecoder.h
@@ -20,8 +20,6 @@
 #ifndef MFX_DECODER_H
 #define MFX_DECODER_H
 
-//#define GET_MFX_VIDEO_PARAMETERS
-
 #include "onevpl-video-decode/MfxFrameConstructor.h"
 #include "VirtualCamera3.h"
 #include <mfxvideo++.h>
@@ -63,18 +61,15 @@ public:
     ~MfxDecoder();
 
     mfxStatus Init(uint32_t codec_type, uint32_t width, uint32_t height);
+    void FreeDecoder();
     void Release();
     mfxStatus DecodeFrame(uint8_t *pData, size_t size);
     bool GetOutput(YCbCrLayout &out);
 
 private:
-    mfxStatus SetVideoParameters(uint32_t codec_type);
     mfxStatus InitDecoder();
     mfxStatus PrepareSurfaces();
     void ClearFrameSurface();
-#ifdef GET_MFX_VIDEO_PARAMETERS
-    mfxStatus GetVideoParameters(mfxBitstream **bit_stream);
-#endif
     void GetAvailableSurface(mfxFrameSurface1 **pWorkSurface);
     uint32_t GetAvailableSurfaceIndex();
 
@@ -91,11 +86,9 @@ private:
 
     uint32_t mResWidth;
     uint32_t mResHeight;
+    uint32_t mCodecType;
 
     bool mIsDecoderInitialized;
-#ifdef GET_MFX_VIDEO_PARAMETERS
-    bool mIsGetVideoParametersDone;
-#endif
 
     std::mutex mDecMutex;
     std::mutex mMemMutex;

--- a/src/VirtualFakeCamera3.cpp
+++ b/src/VirtualFakeCamera3.cpp
@@ -240,9 +240,9 @@ status_t VirtualFakeCamera3::connectCamera() {
         ret = mDecoder->Init(mCodecType, mSrcWidth, mSrcHeight);
         if (ret == MFX_ERR_NONE) {
             mDecoderInitDone = true;
-            ALOGI("%s Video decoder init success!!!", __func__);
+            ALOGI("%s Video mfx init success!!!", __func__);
         } else {
-            ALOGE("%s Video decoder init failed", __func__);
+            ALOGE("%s Video mfx init failed", __func__);
         }
     }
 


### PR DESCRIPTION
When camera is launched using the AIC-Client application, there is no preview and a black screen is seen.

once the camera-vhal receives the encoded frame from client, it will decode the frame but In this case, after receiving the frame from client, decoding the frame is failing with error code -14 that is MFX_ERR_INCOMPATIBLE_VIDEO_PARAM error.

Decoder param codeclevel was not set correctly.

Whenever it fails with this error, re-intialize the decoder with default value instead of using static value.

Tracked-on: OAM-105522
Signed-off-by: Singh, Sapna1 <sapna1.singh@intel.com>