### PR TITLE
Fix for UI not coming when page reloaded with camera app open

### DIFF
--- a/src/ClientCommunicator.cpp
+++ b/src/ClientCommunicator.cpp
@@ -238,12 +238,12 @@ void ClientCommunicator::handleCameraInfo(uint32_t header_size) {
         }
         mValidClientCapInfo = IsValidClientCapInfo;
     }
+    sendAck();
 }
 
 
 void ClientCommunicator::sendAck() {
     ALOGVV("%s(%d) Enter", __FUNCTION__, mClientId);
-    Mutex::Autolock al(mMutex);
     size_t ack_packet_size = sizeof(camera_header_t) + sizeof(camera_ack_t);
     camera_ack_t ack_payload = ACK_CONFIG;
     camera_packet_t *ack_packet = NULL;
@@ -352,11 +352,11 @@ bool ClientCommunicator::clientThread() {
                             if ((mCameraSessionState != CameraSessionState::kCameraOpened)
                                 && (mCameraSessionState != CameraSessionState::kDecodingStarted)) {
                                 gVirtualCameraFactory.clearCameraInfo(mClientId);
-                                sendCameraCapabilities();
-			    } else {
+                            } else {
                                 ALOGE("%s(%d): Camera is in opened or decoding state,"
                                       "avoid clearing the cameras", __FUNCTION__, mClientId);
                             }
+                            sendCameraCapabilities();
                             break;
                         case CAMERA_INFO:
                             mValidClientCapInfo = false;
@@ -373,7 +373,6 @@ bool ClientCommunicator::clientThread() {
 				mNumOfCamerasRequested = (header.size) / sizeof(camera_info_t);
                                 handleCameraInfo(header.size);
                             }
-                            sendAck();
                             break;
                         case CAMERA_DATA:
                             if (!mIsConfigurationDone) {


### PR DESCRIPTION
Whenever camera is opened and URL is reloaded, camera close will be called from framework and on the other side streamer will send capability request to the camera-vhal. camera vhal ignores the capability request as it is received when the camera is in opened state. Streamer is stuck waiting for the response to capability request which results in no UI streamed out.

Fix the issue by handling capability request even when camera  is in opened state in camera vhal.

Tracked-On: OAM-108772