### PR TITLE
Fix for no camera preview in AV1 streaming configuration

### DIFF
--- a/src/CapabilitiesHelper.cpp
+++ b/src/CapabilitiesHelper.cpp
@@ -27,7 +27,8 @@ using namespace socket;
 
 bool CapabilitiesHelper::IsCodecTypeValid(uint32_t CodecType) {
     if ((CodecType == uint32_t(VideoCodecType::kH264))
-          || (CodecType == uint32_t(VideoCodecType::kH265))) {
+          || (CodecType == uint32_t(VideoCodecType::kH265))
+          || (CodecType == uint32_t(VideoCodecType::kAV1))) {
         return true;
     } else
         return false;


### PR DESCRIPTION
When aic is installed with AV1 codec for streaming, black screen is seen in camera preview.

Codec validation only checks for H264 and H265 which results in codec type set to H264 even when AV1 is a valid codec type.

Fix the issue by adding AV1 to valid codec type check.

Tracked-On: OAM-110610