### PR TITLE
The default bootanimation has all its segments type set to "c",wihch …

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # camera-vhal
+
+
+
+
+


### PR DESCRIPTION
…means "this part will play to completion, no matter what".

On ADL IVI platform, it takes less than 2 seconds from bootanimation start to boot finished (and system property "service.bootanim.exit" set). But the default bootanimation is about 6 seconds long, which means the bootanimation will continue playing for 3~4 seconds after the system boot finished and UI ready. This change set some bootanimation segments to type "p" so that the animation can be interrupted by the end of the boot, then the user can see the launcher screen a few seconds earlier. The first 3 parts are kept as "c" and the bootanimation has a minimum duration of about 3s.