### PR TITLE
Static fix camvhal

### DIFF
--- a/src/VirtualFakeCamera3.cpp
+++ b/src/VirtualFakeCamera3.cpp
@@ -3048,8 +3048,12 @@ bool VirtualFakeCamera3::ReadoutThread::threadLoop() {
     result.partial_result = 1;
     /*Coverity Fix:  If the current camera device is not a logical multi-camera, or the
       corresponding capture_request doesn't request on any physical camera,
-      this field must be 0*/
-    result.num_physcam_metadata=0;
+      this field must be 0
+      
+      Since we don't have any Physical Camera, the array of Strings  containing Physical
+      camera Id is NULL*/
+    result.num_physcam_metadata = 0;
+    result.physcam_ids = NULL;
 
     // Go idle if queue is empty, before sending result
     bool signalIdle = false;
@@ -3104,8 +3108,12 @@ void VirtualFakeCamera3::ReadoutThread::onJpegDone(const StreamBuffer &jpegBuffe
 
     /*Coverity Fix:  If the current camera device is not a logical multi-camera, or the
       corresponding capture_request doesn't request on any physical camera,
-      this field must be 0*/
-    result.num_physcam_metadata=0;
+      this field must be 0
+      
+      Since we don't have any Physical Camera, the array of Strings  containing Physical
+      camera Id is NULL*/
+    result.num_physcam_metadata = 0;
+    result.physcam_ids = NULL;
 
     if (!success) {
         ALOGE(

--- a/src/jpeg-stub/Compressor.cpp
+++ b/src/jpeg-stub/Compressor.cpp
@@ -22,7 +22,7 @@
 #include <libexif/exif-data.h>
 
 Compressor::Compressor() {
-    mCompressInfo.script_space_size=0;  //Coverity Fix: Dummily assigned to 0
+    memset(&mCompressInfo, 0, sizeof(mCompressInfo));
 }
 
 bool Compressor::compress(const unsigned char *data, int width, int height, int quality,


### PR DESCRIPTION
    Static Analysis Fix for Camera Vhal

    -Camera-Vhal does not use Physical Camera
    -Correponding Variables are gracefully initialized to NULL

    Tracked-On: OAM-112447
    Signed-off-by: Venkatesh Pillai <venkatesh.pillai@intel.com>
